### PR TITLE
compatibility fix for Java 9

### DIFF
--- a/src/main/java/org/appstart/Starter.java
+++ b/src/main/java/org/appstart/Starter.java
@@ -65,13 +65,13 @@ public class Starter {
     	String configFilename = APPSTART_FALLBACK_CONFIG_FILE;
         if (!Boolean.getBoolean("appstart.verbose")) {
             log.setLevel(Level.WARNING);
-            System.out.println("WARN");
+            //System.out.println("WARN");
         }
         File java = new File(System.getProperty("java.home"), JAVA_PATH);
         log.info("using java in " + java.getParent());
 
         // get the class path URLs
-        URL launcherUrl = ((URLClassLoader) Starter.class.getClassLoader()).getURLs()[0];
+        URL launcherUrl = Starter.class.getProtectionDomain().getCodeSource().getLocation();
 
         File appstartDir = new File(launcherUrl.toURI());
         if (appstartDir.isFile()) {


### PR DESCRIPTION
The system class loader is no longer a URLClassLoader, which means we have to use a different method to get the filesystem path of the current Starter class.
Found a suitable answer here: https://stackoverflow.com/questions/11747833
Successfully tested on Linux with OpenJDK 8 and on Windows 7 with Oracle Java 10.

Fixes issue #1